### PR TITLE
Fix optimizer initialization in NLPCA.create_model

### DIFF
--- a/prinpy/glob.py
+++ b/prinpy/glob.py
@@ -5,7 +5,10 @@ over an entire dataset. Additionally, these algorithms should work
 in space greater than 2-dimensions.
 '''
 
+# General libraries
 import numpy as np
+
+# ML libraries
 import tensorflow as tf
 from tensorflow import keras
 from tensorflow.keras.models import Model

--- a/prinpy/glob.py
+++ b/prinpy/glob.py
@@ -5,18 +5,14 @@ over an entire dataset. Additionally, these algorithms should work
 in space greater than 2-dimensions.
 '''
 
-# General libraries
 import numpy as np
-
-# ML libraries
 import tensorflow as tf
-import keras
-from keras.models import Model
-from keras.layers import Dense, Input, LeakyReLU
-from keras import optimizers
-import keras.backend as k
+from tensorflow import keras
+from tensorflow.keras.models import Model
+from tensorflow.keras.layers import Dense, Input, LeakyReLU
+from tensorflow.keras.optimizers import Adam
+import tensorflow.keras.backend as K
 
-# Preprocessing
 from sklearn.preprocessing import MinMaxScaler, StandardScaler
 
 
@@ -123,7 +119,7 @@ class NLPCA(object):
 
         # Connect and compile model:
         model = Model(inputs = input, outputs = output)
-        gradient_descent = optimizers.adam(learning_rate=lr)
+        gradient_descent = Adam(learning_rate=lr)
         model.compile(loss = orth_dist, optimizer = gradient_descent)
 
         return model

--- a/prinpy/glob.py
+++ b/prinpy/glob.py
@@ -13,6 +13,7 @@ from tensorflow.keras.layers import Dense, Input, LeakyReLU
 from tensorflow.keras.optimizers import Adam
 import tensorflow.keras.backend as K
 
+# Preprocessing
 from sklearn.preprocessing import MinMaxScaler, StandardScaler
 
 


### PR DESCRIPTION
This pull request addresses an issue in the NLPCA.create_model method where the deprecated optimizers.adam call was used, resulting in an AttributeError. The update replaces it with the correct TensorFlow Keras API usage by initializing the Adam optimizer with Adam(learning_rate=lr). This change ensures compatibility with the latest TensorFlow/Keras versions and allows the model to compile and train successfully.